### PR TITLE
Fix: Correct Rickroll lyric display and screen state handling

### DIFF
--- a/index.html.audiocontrols.bak
+++ b/index.html.audiocontrols.bak
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span style="opacity: 0.05; font-style: italic;">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function randomizeVolume() {
+      audio.volume = 0.85 + Math.random() * 0.15;
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit, help = show this list`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+        if (e.key === "v") audioStatus.textContent = `-- volume: ${(audio.volume * 100).toFixed(0)}%`;
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+        if (e.key === "h") showCommands();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.error_pre_adds.bak
+++ b/index.html.error_pre_adds.bak
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function setInitialAudioSettings() {
+    // audio.volume = 0.85 + Math.random() * 0.15; // This was the OLD LINE
+    audio.volume = volumeLevels[currentVolumeIndex]; // NEW: Set to current selected level
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+           setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+    if (e.key === "v") { // NEW LOGIC for cycling 'v'
+      currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+      audio.volume = volumeLevels[currentVolumeIndex];
+      audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+    }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.error_rewrite_script.bak
+++ b/index.html.error_rewrite_script.bak
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+    <span id="errorMessage" style="color: #FF5555; display: block; min-height: 1.5rem;"></span>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const errorMessageEl = document.getElementById("errorMessage");
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function setInitialAudioSettings() {
+    // audio.volume = 0.85 + Math.random() * 0.15; // This was the OLD LINE
+    audio.volume = volumeLevels[currentVolumeIndex]; // NEW: Set to current selected level
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+           setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+    if (e.key === "v") { // NEW LOGIC for cycling 'v'
+      currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+      audio.volume = volumeLevels[currentVolumeIndex];
+      audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+    }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.jonasalign.bak
+++ b/index.html.jonasalign.bak
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span style="opacity: 0.05; font-style: italic;">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function randomizeVolume() {
+    // audio.volume = 0.85 + Math.random() * 0.15; // This was the OLD LINE
+    audio.volume = volumeLevels[currentVolumeIndex]; // NEW: Set to current selected level
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+    if (e.key === "v") { // NEW LOGIC for cycling 'v'
+      currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+      audio.volume = volumeLevels[currentVolumeIndex];
+      audioStatus.textContent = \`-- volume: \${volumeNames[currentVolumeIndex]} (\${(audio.volume * 100).toFixed(0)}%)\`;
+    }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.pre-css-separation.bak
+++ b/index.html.pre-css-separation.bak
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+    <span id="errorMessage" style="color: #FF5555; display: block; min-height: 1.5rem;"></span>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+    }
+
+    function showCommands() { // MODIFIED FUNCTION
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = [
+                "> ARCHIVE DIRECTORY LISTING:",
+                "  JONAS.HVL",
+                ""
+            ].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        // 'r' and 'f' key logic removed
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.pre-js-separation.bak
+++ b/index.html.pre-js-separation.bak
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+  <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+    <span id="errorMessage" style="color: #FF5555; display: block; min-height: 1.5rem;"></span>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+    }
+
+    function showCommands() { // MODIFIED FUNCTION
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = [
+                "> ARCHIVE DIRECTORY LISTING:",
+                "  JONAS.HVL",
+                ""
+            ].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        // 'r' and 'f' key logic removed
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.pre-rickroll-audio-tag.bak
+++ b/index.html.pre-rickroll-audio-tag.bak
@@ -26,7 +26,6 @@
   </div>
   <div class="glitch-bars"></div>
   <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
-  <audio id="rickrollAudio" src="public/nggyu_glitch.mp3"></audio>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html.renamefunc.bak
+++ b/index.html.renamefunc.bak
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function randomizeVolume() {
+    // audio.volume = 0.85 + Math.random() * 0.15; // This was the OLD LINE
+    audio.volume = volumeLevels[currentVolumeIndex]; // NEW: Set to current selected level
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+    if (e.key === "v") { // NEW LOGIC for cycling 'v'
+      currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+      audio.volume = volumeLevels[currentVolumeIndex];
+      audioStatus.textContent = \`-- volume: \${volumeNames[currentVolumeIndex]} (\${(audio.volume * 100).toFixed(0)}%)\`;
+    }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.syntaxfix.bak
+++ b/index.html.syntaxfix.bak
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span class="jonas-hint">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function setInitialAudioSettings() {
+    // audio.volume = 0.85 + Math.random() * 0.15; // This was the OLD LINE
+    audio.volume = volumeLevels[currentVolumeIndex]; // NEW: Set to current selected level
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+           setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+    if (e.key === "v") { // NEW LOGIC for cycling 'v'
+      currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+      audio.volume = volumeLevels[currentVolumeIndex];
+      audioStatus.textContent = \`-- volume: \${volumeNames[currentVolumeIndex]} (\${(audio.volume * 100).toFixed(0)}%)\`;
+    }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html.volumecontrol.bak
+++ b/index.html.volumecontrol.bak
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>terminal.echoesandpaths.blog</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="startup">
+> SYSTEM LINK :: <span class="glitch-char">CORRUPTED</span> MEMORY SECTOR ACCESS<br/>
+> ARCHIVE FILE RECOVERY INTERFACE v7.1<br/><br/>
+> Enter archive file name: <span id="typed"></span><span class="cursor">&nbsp;</span><br/>
+<span style="opacity: 0.05; font-style: italic;">jonas</span>
+  </div>
+  <div id="terminal" style="display:none;">
+// fragment log: node -- 0345.delta.vermillion<br/>
+// signal echo: jonas.hevel://witness/anomaly_004c<br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...they kept it quiet, buried under the first failures..."</span><br/>
+<span class="excerpt glitch-char">// transcribed excerpt: "...I only remember the humming—then the static..."</span><br/>
+// audio signal type: async.packetstream.96kb.quiet-core<br/>
+<div id="audioStatus"></div>
+<div id="endPrompt"></div>
+  </div>
+  <div class="glitch-bars"></div>
+  <audio id="hevelAudio" src="public/jonas_hevel_audio.mp3"></audio>
+  <script>
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(duration)}`;
+      }, 1000);
+    }
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+    function randomizeVolume() {
+      audio.volume = 0.85 + Math.random() * 0.15;
+    }
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, r = rewind 10s, f = forward 10s, v = volume, q = quit`;
+    }
+    audio.addEventListener("ended", handlePlaybackEnd);
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        }
+        if (inputBuffer === "jonas") {
+          startup.style.display = "none";
+          terminal.style.display = "block";
+          playbackStarted = true;
+          updateExcerpts();
+          randomizeVolume();
+          audio.play();
+          monitorAudio();
+          setInterval(updateExcerpts, 6000);
+          showCommands();
+        }
+      } else {
+        if (e.key === "p") audio.paused ? audio.play() : audio.pause();
+        if (e.key === "r") audio.currentTime = Math.max(audio.currentTime - 10, 0);
+        if (e.key === "f") audio.currentTime = Math.min(audio.currentTime + 10, audio.duration);
+        if (e.key === "v") audioStatus.textContent = `-- volume: ${(audio.volume * 100).toFixed(0)}%`;
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = `>> playback terminated.`;
+        }
+      }
+    });
+  </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,230 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const rickrollAudioEl = document.getElementById('rickrollAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    const rickrollLyric = "You know the rules, and so do I...";
+
+    let inputBuffer = "";
+    let playbackStarted = false;
+    let rickrollPlaying = false;
+    let lyricInterval = null;
+
+    function updateExcerpts() {
+      if (rickrollPlaying) return;
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function displayRickrollLyrics() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = rickrollLyric;
+      });
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+      if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+    }
+
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    if (rickrollAudioEl) {
+      rickrollAudioEl.addEventListener("ended", () => {
+        if (lyricInterval) {
+          clearInterval(lyricInterval);
+          lyricInterval = null;
+        }
+        document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+        if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626";
+            errorMessageEl.textContent = ">> UNEXPECTED FRAGMENT PLAYBACK COMPLETED.";
+        }
+        rickrollPlaying = false;
+        inputBuffer = "";
+        if (typed) typed.textContent = inputBuffer;
+
+        // Transition back to startup screen
+        if (terminal) terminal.style.display = "none";
+        if (startup) startup.style.display = "block";
+      });
+    }
+
+    document.addEventListener("keydown", (e) => {
+      if (rickrollPlaying) {
+        if (e.key === "q") {
+          if (rickrollAudioEl) {
+            rickrollAudioEl.pause();
+            rickrollAudioEl.currentTime = 0;
+          }
+          if (lyricInterval) {
+            clearInterval(lyricInterval);
+            lyricInterval = null;
+          }
+          document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+          if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626";
+            errorMessageEl.innerHTML = "> ADMIN OVERRIDE TERMINATED.";
+          }
+          rickrollPlaying = false;
+          inputBuffer = "";
+          if(typed) typed.textContent = inputBuffer;
+
+          // Transition back to startup screen
+          if (terminal) terminal.style.display = "none";
+          if (startup) startup.style.display = "block";
+        }
+        return;
+      }
+
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "admin") {
+            if (errorMessageEl) errorMessageEl.textContent = "";
+            if (errorMessageEl) { // This message shows on startup screen
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.innerHTML = "> EXECUTING ADMIN OVERRIDE...<br/>> WARNING: UNSTABLE FRAGMENT DETECTED...";
+            }
+            setTimeout(() => {
+                // Show terminal for lyrics, hide startup
+                if (startup) startup.style.display = "none";
+                if (terminal) terminal.style.display = "block";
+                document.querySelectorAll(".excerpt").forEach(el => el.textContent = ""); // Clear normal excerpts
+
+                if (errorMessageEl) { // Clear initial admin messages from startup screen area
+                    errorMessageEl.textContent = "";
+                }
+                // Message for terminal view's status line
+                if (audioStatus) audioStatus.textContent = "-- playing: R1CK.HVL --";
+
+
+                if (rickrollAudioEl) {
+                    rickrollAudioEl.volume = audio.volume;
+                    rickrollAudioEl.play();
+                    rickrollPlaying = true;
+                    if (lyricInterval) clearInterval(lyricInterval);
+                    lyricInterval = setInterval(displayRickrollLyrics, 2000); // Faster interval
+                    displayRickrollLyrics();
+                } else {
+                    // This error would now show on the (blank) terminal screen's audioStatus or endPrompt ideally
+                    // For now, it might try errorMessageEl which is on the hidden startup screen.
+                    // Let's ensure it's visible by temporarily showing startup or using a terminal element.
+                    // Given current structure, let's put it in audioStatus as that's on terminal.
+                    if (audioStatus) audioStatus.textContent = "> ERROR: Special audio module not found.";
+                     // If error, revert to startup
+                    if (terminal) terminal.style.display = "none";
+                    if (startup) startup.style.display = "block";
+                }
+            }, 1500);
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = ["> ARCHIVE DIRECTORY LISTING:","  JONAS.HVL",""].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true (and rickrollPlaying is false)
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+          // Also ensure terminal stays, startup hidden (current state for main audio quit)
+          if (startup) startup.style.display = "none";
+          if (terminal) terminal.style.display = "block";
+        }
+      }
+    });

--- a/script.js.pre-admin-cmd.bak
+++ b/script.js.pre-admin-cmd.bak
@@ -1,0 +1,163 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+
+
+const rickrollLyrics = [
+  "We're no strangers to love...",
+  "You know the rules, and so do I...",
+  "A full commitment's what I'm thinking of...",
+  "You wouldn't get this from any other guy...",
+  "I just wanna tell you how I'm feeling...",
+  "Gotta make you understand...",
+  "",
+  "Never gonna give you up,",
+  "Never gonna let you down,",
+  "Never gonna run around and desert you.",
+  "Never gonna make you cry,",
+  "Never gonna say goodbye,",
+  "Never gonna tell a lie and hurt you.",
+  "",
+  "We've known each other for so long...",
+  "Your heart's been aching, but you're too shy to say it...",
+  "Inside, we both know what's been going on...",
+  "We know the game and we're gonna play it...",
+  "",
+  "And if you ask me how I'm feeling...",
+  "Don't tell me you're too blind to see...",
+  "",
+  "Never gonna give you up,",
+  "Never gonna let you down,",
+  "Never gonna run around and desert you.",
+  "Never gonna make you cry,",
+  "Never gonna say goodbye,",
+  "Never gonna tell a lie and hurt you."
+];
+    let inputBuffer = "";
+    let playbackStarted = false;
+
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+    }
+
+    function showCommands() { // MODIFIED FUNCTION
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = [
+                "> ARCHIVE DIRECTORY LISTING:",
+                "  JONAS.HVL",
+                ""
+            ].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        // 'r' and 'f' key logic removed
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/script.js.pre-lyric-flash.bak
+++ b/script.js.pre-lyric-flash.bak
@@ -1,0 +1,247 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const rickrollAudioEl = document.getElementById('rickrollAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    const rickrollLyrics = [
+      "We're no strangers to love...",
+      "You know the rules, and so do I...",
+      "A full commitment's what I'm thinking of...",
+      "You wouldn't get this from any other guy...",
+      "I just wanna tell you how I'm feeling...",
+      "Gotta make you understand...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you.",
+      "",
+      "We've known each other for so long...",
+      "Your heart's been aching, but you're too shy to say it...",
+      "Inside, we both know what's been going on...",
+      "We know the game and we're gonna play it...",
+      "",
+      "And if you ask me how I'm feeling...",
+      "Don't tell me you're too blind to see...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you."
+    ];
+
+    let inputBuffer = "";
+    let playbackStarted = false;
+    let rickrollPlaying = false;
+    let lyricInterval = null;
+    let currentLyricIndex = 0;
+
+    function updateExcerpts() {
+      if (rickrollPlaying) return;
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function displayRickrollLyrics() {
+      if (currentLyricIndex < rickrollLyrics.length) {
+        document.querySelectorAll(".excerpt").forEach(el => {
+          el.textContent = rickrollLyrics[currentLyricIndex];
+        });
+        currentLyricIndex++;
+      } else {
+        if (lyricInterval) clearInterval(lyricInterval);
+        lyricInterval = null; // Important to nullify after clearing
+        currentLyricIndex = 0;
+      }
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() { // For main audio
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+      if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+    }
+
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    if (rickrollAudioEl) { // Add listener for Rickroll audio end
+      rickrollAudioEl.addEventListener("ended", () => {
+        if (lyricInterval) {
+          clearInterval(lyricInterval);
+          lyricInterval = null;
+        }
+        document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+
+        if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626";
+            errorMessageEl.textContent = ">> UNEXPECTED FRAGMENT PLAYBACK COMPLETED.";
+        }
+
+        rickrollPlaying = false;
+        currentLyricIndex = 0;
+
+        inputBuffer = "";
+        if (typed) typed.textContent = inputBuffer;
+      });
+    }
+
+    document.addEventListener("keydown", (e) => {
+      if (rickrollPlaying) {
+        if (e.key === "q") {
+          if (rickrollAudioEl) {
+            rickrollAudioEl.pause();
+            rickrollAudioEl.currentTime = 0;
+          }
+          if (lyricInterval) {
+            clearInterval(lyricInterval);
+            lyricInterval = null;
+          }
+          document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+          if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626"; // Normal color for this message
+            errorMessageEl.innerHTML = "> ADMIN OVERRIDE TERMINATED.";
+          }
+          rickrollPlaying = false;
+          currentLyricIndex = 0;
+          inputBuffer = "";
+          if(typed) typed.textContent = inputBuffer;
+        }
+        return;
+      }
+
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "admin") {
+            if (errorMessageEl) errorMessageEl.textContent = "";
+            if (errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.innerHTML = "> EXECUTING ADMIN OVERRIDE...<br/>> WARNING: UNSTABLE FRAGMENT DETECTED...";
+            }
+            setTimeout(() => {
+                if (errorMessageEl) {
+                    errorMessageEl.style.color = "#4AF626";
+                    errorMessageEl.innerHTML = "> PLAYING RECOVERED AUDIO FRAGMENT...";
+                }
+                if (rickrollAudioEl) {
+                    rickrollAudioEl.volume = audio.volume;
+                    rickrollAudioEl.play();
+                    rickrollPlaying = true;
+                    currentLyricIndex = 0;
+                    if (lyricInterval) clearInterval(lyricInterval);
+                    lyricInterval = setInterval(displayRickrollLyrics, 3000);
+                    displayRickrollLyrics();
+                } else {
+                    if(errorMessageEl) errorMessageEl.textContent = "> ERROR: Special audio module not found.";
+                }
+            }, 1500);
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = ["> ARCHIVE DIRECTORY LISTING:","  JONAS.HVL",""].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true (and rickrollPlaying is false)
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/script.js.pre-lyrics.bak
+++ b/script.js.pre-lyrics.bak
@@ -1,0 +1,131 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    let inputBuffer = "";
+    let playbackStarted = false;
+
+    function updateExcerpts() {
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+    }
+
+    function showCommands() { // MODIFIED FUNCTION
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    document.addEventListener("keydown", (e) => {
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = [
+                "> ARCHIVE DIRECTORY LISTING:",
+                "  JONAS.HVL",
+                ""
+            ].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        // 'r' and 'f' key logic removed
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/script.js.pre-q-rickroll.bak
+++ b/script.js.pre-q-rickroll.bak
@@ -1,0 +1,217 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const rickrollAudioEl = document.getElementById('rickrollAudio'); // New audio element
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    const rickrollLyrics = [ // As defined in previous step
+      "We're no strangers to love...",
+      "You know the rules, and so do I...",
+      "A full commitment's what I'm thinking of...",
+      "You wouldn't get this from any other guy...",
+      "I just wanna tell you how I'm feeling...",
+      "Gotta make you understand...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you.",
+      "",
+      "We've known each other for so long...",
+      "Your heart's been aching, but you're too shy to say it...",
+      "Inside, we both know what's been going on...",
+      "We know the game and we're gonna play it...",
+      "",
+      "And if you ask me how I'm feeling...",
+      "Don't tell me you're too blind to see...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you."
+    ];
+
+    let inputBuffer = "";
+    let playbackStarted = false;
+    let rickrollPlaying = false; // New flag for Rickroll state
+    let lyricInterval = null;    // Interval ID for lyrics display
+    let currentLyricIndex = 0;   // To track current lyric line
+
+    function updateExcerpts() {
+      // If Rickroll is playing, don't update with normal excerpts
+      if (rickrollPlaying) return;
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function displayRickrollLyrics() {
+      if (currentLyricIndex < rickrollLyrics.length) {
+        document.querySelectorAll(".excerpt").forEach(el => {
+          // For now, set all excerpts to the current lyric line.
+          // Could be enhanced to show different lines or scroll.
+          el.textContent = rickrollLyrics[currentLyricIndex];
+        });
+        currentLyricIndex++;
+      } else {
+        if (lyricInterval) clearInterval(lyricInterval);
+        currentLyricIndex = 0;
+        // Optionally clear excerpts or leave last lyric after song naturally ends
+        // document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+      }
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+      // Set rickroll audio volume too, perhaps, or handle it when it plays
+      if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+    }
+
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+    // Rickroll audio end listener will be added in a later step.
+
+    document.addEventListener("keydown", (e) => {
+      if (rickrollPlaying) { // If Rickroll is active, only 'q' should work for now
+        if (e.key === "q") {
+          // Quit logic for Rickroll will be handled in next step
+        }
+        return; // Absorb other key presses during Rickroll
+      }
+
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "admin") { // 'admin' command
+            if (errorMessageEl) errorMessageEl.textContent = "";
+            if (errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.innerHTML = "> EXECUTING ADMIN OVERRIDE...<br/>> WARNING: UNSTABLE FRAGMENT DETECTED...";
+            }
+            setTimeout(() => {
+                if (errorMessageEl) {
+                    errorMessageEl.style.color = "#4AF626";
+                    errorMessageEl.innerHTML = "> PLAYING RECOVERED AUDIO FRAGMENT...";
+                }
+                if (rickrollAudioEl) {
+                    rickrollAudioEl.volume = audio.volume;
+                    rickrollAudioEl.play();
+                    rickrollPlaying = true;
+                    currentLyricIndex = 0;
+                    if (lyricInterval) clearInterval(lyricInterval);
+                    lyricInterval = setInterval(displayRickrollLyrics, 3000);
+                    displayRickrollLyrics();
+                } else {
+                    if(errorMessageEl) errorMessageEl.textContent = "> ERROR: Special audio module not found.";
+                }
+            }, 1500);
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = ["> ARCHIVE DIRECTORY LISTING:","  JONAS.HVL",""].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true (and rickrollPlaying is false)
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume; // Sync volume
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          // This 'q' is for main audio; Rickroll 'q' handled above or next step
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/script.js.pre-rickroll-display.bak
+++ b/script.js.pre-rickroll-display.bak
@@ -1,0 +1,209 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const rickrollAudioEl = document.getElementById('rickrollAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    const rickrollLyric = "You know the rules, and so do I..."; // MODIFIED
+
+    let inputBuffer = "";
+    let playbackStarted = false;
+    let rickrollPlaying = false;
+    let lyricInterval = null;
+    // currentLyricIndex is removed
+
+    function updateExcerpts() {
+      if (rickrollPlaying) return;
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function displayRickrollLyrics() { // MODIFIED
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = rickrollLyric;
+      });
+      // No more currentLyricIndex or stopping interval here; interval controls refresh, stop on quit/end.
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+      if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+    }
+
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+
+    if (rickrollAudioEl) {
+      rickrollAudioEl.addEventListener("ended", () => {
+        if (lyricInterval) {
+          clearInterval(lyricInterval);
+          lyricInterval = null;
+        }
+        document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+        if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626";
+            errorMessageEl.textContent = ">> UNEXPECTED FRAGMENT PLAYBACK COMPLETED.";
+        }
+        rickrollPlaying = false;
+        // currentLyricIndex already removed
+        inputBuffer = "";
+        if (typed) typed.textContent = inputBuffer;
+      });
+    }
+
+    document.addEventListener("keydown", (e) => {
+      if (rickrollPlaying) {
+        if (e.key === "q") {
+          if (rickrollAudioEl) {
+            rickrollAudioEl.pause();
+            rickrollAudioEl.currentTime = 0;
+          }
+          if (lyricInterval) {
+            clearInterval(lyricInterval);
+            lyricInterval = null;
+          }
+          document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+          if (errorMessageEl) {
+            errorMessageEl.style.color = "#4AF626";
+            errorMessageEl.innerHTML = "> ADMIN OVERRIDE TERMINATED.";
+          }
+          rickrollPlaying = false;
+          // currentLyricIndex already removed
+          inputBuffer = "";
+          if(typed) typed.textContent = inputBuffer;
+        }
+        return;
+      }
+
+      if (!playbackStarted) {
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "admin") {
+            if (errorMessageEl) errorMessageEl.textContent = "";
+            if (errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.innerHTML = "> EXECUTING ADMIN OVERRIDE...<br/>> WARNING: UNSTABLE FRAGMENT DETECTED...";
+            }
+            setTimeout(() => {
+                if (errorMessageEl) {
+                    errorMessageEl.style.color = "#4AF626";
+                    errorMessageEl.innerHTML = "> PLAYING RECOVERED AUDIO FRAGMENT...";
+                }
+                if (rickrollAudioEl) {
+                    rickrollAudioEl.volume = audio.volume;
+                    rickrollAudioEl.play();
+                    rickrollPlaying = true;
+                    // currentLyricIndex removed, displayRickrollLyrics will use the const
+                    if (lyricInterval) clearInterval(lyricInterval);
+                    lyricInterval = setInterval(displayRickrollLyrics, 3000); // Re-asserts the line
+                    displayRickrollLyrics(); // Display first instance immediately
+                } else {
+                    if(errorMessageEl) errorMessageEl.textContent = "> ERROR: Special audio module not found.";
+                }
+            }, 1500);
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = ["> ARCHIVE DIRECTORY LISTING:","  JONAS.HVL",""].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true (and rickrollPlaying is false)
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/script.js.pre-rickroll-end.bak
+++ b/script.js.pre-rickroll-end.bak
@@ -1,0 +1,234 @@
+    const volumeLevels = [0.2, 0.5, 0.9]; // Low, Medium, High
+    const volumeNames = ["Low", "Medium", "High"];
+    let currentVolumeIndex = 1; // Start at Medium
+    const errorMessageEl = document.getElementById('errorMessage');
+    const audio = document.getElementById('hevelAudio');
+    const rickrollAudioEl = document.getElementById('rickrollAudio');
+    const startup = document.getElementById('startup');
+    const terminal = document.getElementById('terminal');
+    const typed = document.getElementById('typed');
+    const audioStatus = document.getElementById('audioStatus');
+    const endPrompt = document.getElementById('endPrompt');
+
+    const excerpts = [
+      '"…they kept it quiet, buried under the first failures…"','"…I only remember the humming—then the static…"','"…we weren’t meant to hear this again…"','"…they called it recursion loss, whatever that means…"','"…he said the name before everything fell silent…"'
+    ];
+    const rickrollLyrics = [
+      "We're no strangers to love...",
+      "You know the rules, and so do I...",
+      "A full commitment's what I'm thinking of...",
+      "You wouldn't get this from any other guy...",
+      "I just wanna tell you how I'm feeling...",
+      "Gotta make you understand...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you.",
+      "",
+      "We've known each other for so long...",
+      "Your heart's been aching, but you're too shy to say it...",
+      "Inside, we both know what's been going on...",
+      "We know the game and we're gonna play it...",
+      "",
+      "And if you ask me how I'm feeling...",
+      "Don't tell me you're too blind to see...",
+      "",
+      "Never gonna give you up,",
+      "Never gonna let you down,",
+      "Never gonna run around and desert you.",
+      "Never gonna make you cry,",
+      "Never gonna say goodbye,",
+      "Never gonna tell a lie and hurt you."
+    ];
+
+    let inputBuffer = "";
+    let playbackStarted = false;
+    let rickrollPlaying = false;
+    let lyricInterval = null;
+    let currentLyricIndex = 0;
+
+    function updateExcerpts() {
+      if (rickrollPlaying) return;
+      document.querySelectorAll(".excerpt").forEach(el => {
+        el.textContent = "// transcribed excerpt: " + excerpts[Math.floor(Math.random() * excerpts.length)];
+      });
+    }
+
+    function displayRickrollLyrics() {
+      if (currentLyricIndex < rickrollLyrics.length) {
+        document.querySelectorAll(".excerpt").forEach(el => {
+          el.textContent = rickrollLyrics[currentLyricIndex];
+        });
+        currentLyricIndex++;
+      } else {
+        if (lyricInterval) clearInterval(lyricInterval);
+        currentLyricIndex = 0;
+      }
+    }
+
+    function formatTime(s) {
+      const m = Math.floor(s / 60).toString().padStart(2, '0');
+      const sec = Math.floor(s % 60).toString().padStart(2, '0');
+      return `${m}:${sec}`;
+    }
+
+    function monitorAudio() {
+      const duration = audio.duration || 200;
+      const displayDuration = (audio.duration && isFinite(audio.duration) && audio.duration > 0) ? audio.duration : 200;
+      const interval = setInterval(() => {
+        if (audio.paused || audio.ended) { clearInterval(interval); return; }
+        audioStatus.textContent = `-- time: ${formatTime(audio.currentTime)} / ${formatTime(displayDuration)}`;
+      }, 1000);
+    }
+
+    function handlePlaybackEnd() {
+      endPrompt.innerHTML = `>> end of audio signal<br/>play again? (y/n)`;
+      document.addEventListener("keydown", function handler(e) {
+        if (e.key === "y") {
+          endPrompt.innerHTML = "";
+          updateExcerpts();
+          setInitialAudioSettings();
+          audio.play();
+          monitorAudio();
+          document.removeEventListener("keydown", handler);
+        } else if (e.key === "n") {
+          endPrompt.innerHTML = `>> link closed.`;
+          document.removeEventListener("keydown", handler);
+        }
+      });
+    }
+
+    function setInitialAudioSettings() {
+      audio.volume = volumeLevels[currentVolumeIndex];
+      if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+    }
+
+    function showCommands() {
+      endPrompt.innerHTML += `<br/>> commands: p = pause/play, v = volume, q = quit`;
+    }
+
+    audio.addEventListener("ended", handlePlaybackEnd);
+    // Rickroll audio end listener will be added in the next step.
+
+    document.addEventListener("keydown", (e) => {
+      if (rickrollPlaying) {
+        if (e.key === "q") { // 'q' TO QUIT RICKROLL
+          if (rickrollAudioEl) {
+            rickrollAudioEl.pause();
+            rickrollAudioEl.currentTime = 0;
+          }
+          if (lyricInterval) {
+            clearInterval(lyricInterval);
+            lyricInterval = null;
+          }
+          document.querySelectorAll(".excerpt").forEach(el => el.textContent = "");
+          if (errorMessageEl) {
+            errorMessageEl.textContent = "";
+          }
+          // endPrompt is used for main audio messages, let's use errorMessageEl for this
+          // or a dedicated status line if we had one. For now, clear it or use it.
+          if (errorMessageEl) errorMessageEl.innerHTML = "> ADMIN OVERRIDE TERMINATED.";
+
+          rickrollPlaying = false;
+          currentLyricIndex = 0;
+          // After quitting Rickroll, the user is back at the startup prompt.
+          // If normal excerpts should show, call updateExcerpts(), but they only show in terminal view.
+          // Clearing inputBuffer and typed.textContent is good practice here.
+          inputBuffer = "";
+          if(typed) typed.textContent = inputBuffer;
+
+        }
+        return; // Absorb other key presses during Rickroll
+      }
+
+      if (!playbackStarted) {
+        // ... (logic for list, dir, admin, jonas, other input - unchanged from previous step)
+        if (e.key.length === 1 && /^[a-zA-Z0-9]$/.test(e.key)) {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer += e.key.toLowerCase();
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Backspace") {
+          if(errorMessageEl) errorMessageEl.textContent = "";
+          inputBuffer = inputBuffer.slice(0, -1);
+          typed.textContent = inputBuffer;
+        } else if (e.key === "Enter") {
+          if (inputBuffer === "admin") {
+            if (errorMessageEl) errorMessageEl.textContent = "";
+            if (errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.innerHTML = "> EXECUTING ADMIN OVERRIDE...<br/>> WARNING: UNSTABLE FRAGMENT DETECTED...";
+            }
+            setTimeout(() => {
+                if (errorMessageEl) {
+                    errorMessageEl.style.color = "#4AF626";
+                    errorMessageEl.innerHTML = "> PLAYING RECOVERED AUDIO FRAGMENT...";
+                }
+                if (rickrollAudioEl) {
+                    rickrollAudioEl.volume = audio.volume;
+                    rickrollAudioEl.play();
+                    rickrollPlaying = true;
+                    currentLyricIndex = 0;
+                    if (lyricInterval) clearInterval(lyricInterval);
+                    lyricInterval = setInterval(displayRickrollLyrics, 3000);
+                    displayRickrollLyrics();
+                } else {
+                    if(errorMessageEl) errorMessageEl.textContent = "> ERROR: Special audio module not found.";
+                }
+            }, 1500);
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "list" || inputBuffer === "dir") {
+            const listOutput = ["> ARCHIVE DIRECTORY LISTING:","  JONAS.HVL",""].join("<br/>");
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#4AF626";
+                errorMessageEl.innerHTML = listOutput;
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else if (inputBuffer === "jonas") {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+            startup.style.display = "none";
+            terminal.style.display = "block";
+            playbackStarted = true;
+            updateExcerpts();
+            setInitialAudioSettings();
+            audio.play();
+            monitorAudio();
+            setInterval(updateExcerpts, 6000);
+            showCommands();
+          } else if (inputBuffer.length > 0) {
+            if(errorMessageEl) {
+                errorMessageEl.style.color = "#FF5555";
+                errorMessageEl.textContent = "> ACCESS DENIED: Unknown archive.";
+            }
+            inputBuffer = "";
+            typed.textContent = "";
+          } else {
+            if(errorMessageEl) errorMessageEl.textContent = "";
+          }
+        }
+      } else { // playbackStarted is true (and rickrollPlaying is false)
+        if (e.key === "p") {
+          if (audio.paused) {
+            audio.play();
+            monitorAudio();
+          } else {
+            audio.pause();
+          }
+        }
+        if (e.key === "v") {
+          currentVolumeIndex = (currentVolumeIndex + 1) % volumeLevels.length;
+          audio.volume = volumeLevels[currentVolumeIndex];
+          if (rickrollAudioEl) rickrollAudioEl.volume = audio.volume;
+          audioStatus.textContent = `-- volume: ${volumeNames[currentVolumeIndex]} (${(audio.volume * 100).toFixed(0)}%)`;
+        }
+        if (e.key === "q") {
+          audio.pause();
+          audio.currentTime = 0;
+          endPrompt.innerHTML = ">> playback terminated.";
+        }
+      }
+    });

--- a/style.css
+++ b/style.css
@@ -1,0 +1,95 @@
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      background: black;
+      font-family: 'Courier New', Courier, monospace;
+      overflow: hidden;
+      color: #4AF626;
+      animation: flicker 3s infinite;
+      border-radius: 15px;
+      box-shadow: 0 0 60px rgba(74, 246, 38, 0.15) inset;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.03) 0px,
+        rgba(255, 255, 255, 0.03) 1px,
+        transparent 1px,
+        transparent 2px
+      );
+      animation: scanlines-pulse 2s infinite;
+      z-index: 10;
+      pointer-events: none;
+    }
+    @keyframes scanlines-pulse {
+      0%, 100% { opacity: 0.05; }
+      50% { opacity: 0.1; }
+    }
+    @keyframes flicker {
+      0%, 19%, 21%, 23%, 25%, 54%, 100% { opacity: 1; }
+      20%, 22%, 24%, 55% { opacity: 0.95; }
+    }
+    #startup, #terminal {
+      position: absolute;
+      top: 10vh;
+      left: 5vw;
+      width: 90vw;
+      white-space: pre-wrap;
+      font-size: 1.1rem;
+      line-height: 1.75rem;
+      z-index: 2;
+      text-shadow: 0 0 5px #4AF626, 0 0 10px #4AF626, 0 0 20px #4AF626;
+    }
+    .cursor {
+      display: inline-block;
+      width: 10px;
+      background: #4AF626;
+      animation: blink 1s step-end infinite;
+    }
+    @keyframes blink { 50% { opacity: 0; } }
+    .glitch-bars {
+      position: fixed;
+      top: -100px;
+      left: 0;
+      width: 100%;
+      height: 60px;
+      background: linear-gradient(to bottom,
+        rgba(74, 246, 38, 0.4) 0%,
+        rgba(74, 246, 38, 0.15) 50%,
+        transparent 100%
+      );
+      z-index: 8;
+      pointer-events: none;
+      animation: glitchRoll 8s infinite ease-in-out;
+    }
+    @keyframes glitchRoll {
+      0%, 95%, 100% { transform: translateY(-120%); opacity: 0; }
+      45% { transform: translateY(100vh); opacity: 0.3; }
+      46% { opacity: 0; }
+    }
+    .glitch-char {
+      display: inline-block;
+      animation: glitchChar 4s infinite steps(1, end);
+    }
+    @keyframes glitchChar {
+      0%, 98%, 100% { opacity: 1; transform: none; filter: none; }
+      2% {
+        opacity: 0.6;
+        transform: scaleX(1.3) skewX(10deg);
+        filter: blur(1px);
+      }
+      3% {
+        transform: scaleX(0.9) skewX(-5deg);
+        filter: contrast(200%);
+      }
+    }
+    .jonas-hint {
+      opacity: 0.05;
+      font-style: italic;
+      padding-left: 28ch; /* For prompt alignment */
+    }


### PR DESCRIPTION
This commit ensures the Rickroll easter egg displays its lyric line correctly and manages screen transitions smoothly.

- When the 'admin' command triggers the Rickroll:
    - The startup screen (`div#startup`) is now hidden.
    - The main terminal screen (`div#terminal`) is shown.
    - The lyric "You know the rules and so do I..." is displayed in the `.excerpt` elements within the terminal view.
    - `audioStatus` is updated to reflect the special audio fragment playing.
- When the Rickroll is quit (via 'q') or ends naturally:
    - The `terminal` screen is hidden.
    - The `startup` screen is shown again, returning you to the initial prompt.
    - Appropriate completion or termination messages are displayed on the startup screen. This resolves the issue of lyrics not being visible by ensuring they are rendered in a visible view.